### PR TITLE
feat: add cleanup script to remove old harbor images

### DIFF
--- a/.github/workflows/build-and-update-notebook-image.yml
+++ b/.github/workflows/build-and-update-notebook-image.yml
@@ -22,7 +22,8 @@ jobs:
           chmod 600 ~/.kube/config
 
       - name: Extract short commit hash
-        run: echo "TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+        id: commit
+        run: echo "hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Login to OVH Harbor docker registry
         uses: docker/login-action@v3
@@ -34,7 +35,7 @@ jobs:
       - name: Build and push docker image
         working-directory: deployment
         run: |
-          make build-and-push-docker-image TAG=$TAG
+          make build-and-push-docker-image TAG=release-${{ steps.commit.outputs.hash }}
           make tag-docker-image TAG=latest
           make push-docker-image TAG=latest
 
@@ -49,4 +50,4 @@ jobs:
           --namespace eopf-toolkit-dev \
           --version=4.2.0 \
           --values config.yaml \
-          --set-string 'singleuser.profileList[1].kubespawner_override.image=${{ secrets.OVH_HARBOR_REGISTRY }}/eopf-toolkit-dev/eopf-toolkit-dev:${{ env.TAG }}'
+          --set-string 'singleuser.profileList[1].kubespawner_override.image=${{ secrets.OVH_HARBOR_REGISTRY }}/eopf-toolkit-dev/eopf-toolkit-dev:release-${{ steps.commit.outputs.hash }}'

--- a/.github/workflows/clean-harbor.py
+++ b/.github/workflows/clean-harbor.py
@@ -1,0 +1,59 @@
+import os
+import requests
+import re
+from datetime import datetime, timedelta
+
+HARBOR_URL = os.environ["OVH_HARBOR_REGISTRY"]
+PROJECT = "eopf-toolkit-dev"
+REPO = "eopf-toolkit-dev"
+USERNAME = os.environ["OVH_HARBOR_ROBOT_USERNAME"]
+PASSWORD = os.environ["OVH_HARBOR_ROBOT_PASSWORD"]
+DAYS_OLD = int(os.environ["IMAGE_CLEANUP_DAYS"])
+TARGET_REGEX = re.compile(r"^(pr-.*|release-.*)$")
+CUTOFF = datetime.now() - timedelta(days=DAYS_OLD)
+
+
+url = f"{HARBOR_URL}/api/v2.0/projects/{PROJECT}/repositories/{REPO}/artifacts?page_size=100"
+resp = requests.get(url, auth=(USERNAME, PASSWORD), headers={
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+})
+resp.raise_for_status()
+
+artifacts = resp.json()
+
+for artifact in artifacts:
+    tags = artifact.get("tags", [])
+    if not tags:
+        continue
+
+    tag_names = {tag["name"] for tag in tags}
+    if "latest" in tag_names:
+        print(f"Skipping artifact {artifact['digest']} — has 'latest'")
+        continue
+
+    for tag in tags:
+        name = tag["name"]
+        if not TARGET_REGEX.match(name):
+            continue
+
+        pushed = datetime.strptime(tag["push_time"], "%Y-%m-%dT%H:%M:%S.%fZ")
+        if pushed >= CUTOFF:
+            continue
+
+        digest = artifact["digest"]
+        print(f"Deleting artifact {digest} due to tag '{name}' (pushed {pushed})")
+        del_url = f"{HARBOR_URL}/api/v2.0/projects/{PROJECT}/repositories/{REPO}/artifacts/{digest}"
+        del_resp = requests.delete(
+            del_url, 
+            auth=(USERNAME, PASSWORD),
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json"
+            }
+        )
+        if del_resp.status_code == 200:
+            print(f"Deleted {name}")
+        else:
+            print(f"Failed to delete {name}: {del_resp.status_code} {del_resp.text}")
+        break

--- a/.github/workflows/clean-harbor.yml
+++ b/.github/workflows/clean-harbor.yml
@@ -1,0 +1,30 @@
+name: Cleanup Harbor Images
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'  # Runs daily at 00:00 UTC
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_CLEANUP_DAYS: 7
+      OVH_HARBOR_REGISTRY: ${{ secrets.OVH_HARBOR_REGISTRY }}
+      OVH_HARBOR_ROBOT_USERNAME: ${{ secrets.OVH_HARBOR_ROBOT_USERNAME }}
+      OVH_HARBOR_ROBOT_PASSWORD: ${{ secrets.OVH_HARBOR_ROBOT_PASSWORD }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run Harbor cleanup script
+        run: python .github/workflows/clean-harbor.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           if echo "$CHANGED_FILES" | grep -qE '^pyproject\.toml$|^deployment/Dockerfile$'; then
             echo "Building image as we've modified pyproject.toml or deployment Dockerfile in this PR"
             echo "build=true" >> $GITHUB_OUTPUT
-            echo "tag=${{ github.run_id }}" >> $GITHUB_OUTPUT
+            echo "tag=pr-${{ github.run_id }}" >> $GITHUB_OUTPUT
           else
             echo "Using latest image"
             echo "build=false" >> $GITHUB_OUTPUT
@@ -52,7 +52,7 @@ jobs:
         working-directory: deployment
         if: needs.check-diff.outputs.build == 'true'
         run: |
-          make build-and-push-docker-image TAG=${{ github.run_id }}
+          make build-and-push-docker-image TAG=${{ needs.check-diff.outputs.tag }}
 
   test-render:
     needs: [check-diff, prepare-docker-image]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     { name = "Emmanuel Mathot", email = "emmanuel@developmentseed.com" },
     { name = "Gisela Romero Candanedo" },
     { name = "Julia Wagemann" },
-    { name = "Ciaran Sweet ", email = "ciaran@developmentseed.org" }
+    { name = "Ciaran Sweet", email = "ciaran@developmentseed.org" }
 ]
 license = { text = "MIT" }
 keywords = [


### PR DESCRIPTION
# What this PR is

This at a high level adds a nightly CRON job to remove images that aren't `latest` or less than a day old (to keep PRs/releases from poluting harbor) - We can tweak this later on

It also changes some tagging values
