### PR TITLE
feat: remove dual images and serve only new slim image on hub

### DIFF
--- a/.github/workflows/build-and-update-notebook-image.yml
+++ b/.github/workflows/build-and-update-notebook-image.yml
@@ -50,4 +50,4 @@ jobs:
           --namespace eopf-toolkit-dev \
           --version=4.2.0 \
           --values config.yaml \
-          --set-string 'singleuser.profileList[1].kubespawner_override.image=${{ secrets.OVH_HARBOR_REGISTRY }}/eopf-toolkit-dev/eopf-toolkit-dev:release-${{ steps.commit.outputs.hash }}'
+          --set-string 'singleuser.image.tag=release-${{ steps.commit.outputs.hash }}'

--- a/deployment/config.yaml
+++ b/deployment/config.yaml
@@ -44,21 +44,8 @@ hub:
       c.GitHubOAuthenticator.client_secret = os.environ["OAUTH_CLIENT_SECRET"]
 singleuser:
   image:
-    # You should replace the "latest" tag with a fixed version from:
-    # https://hub.docker.com/r/jupyter/datascience-notebook/tags/
-    # Inspect the Dockerfile at:
-    # https://github.com/jupyter/docker-stacks/tree/HEAD/datascience-notebook/Dockerfile
+    # This `latest` should ideally be replaced during CI deployments
     name: 4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-dev/eopf-toolkit-dev
-    tag: "202504241023"
+    tag: "latest"
     pullSecrets:
       - name: regcred
-  profileList:
-    - display_name: "Original environment"
-      description: "The original 'full' environment for eopf-toolkit-dev"
-      default: true
-    - display_name: "Reduced, new environment"
-      description: "The new environment based on pyproject.toml"
-      kubespawner_override:
-        image: 4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-dev/eopf-toolkit-dev:202506031328
-        pullSecrets:
-          - name: regcred

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ authors = [
     { name = "Emmanuel Mathot", email = "emmanuel@developmentseed.com" },
     { name = "Gisela Romero Candanedo" },
     { name = "Julia Wagemann" },
-    { name = "Ciaran Sweet", email = "ciaran@developmentseed.org" }
+    { name = "Ciaran Sweet", email = "ciaran@developmentseed.org" },
+    { name = "Felix Delattre", email = "felix@developmentseed.org" }
 ]
 license = { text = "MIT" }
 keywords = [


### PR DESCRIPTION
# What this PR is

This PR removes the dual image option from JupyterHub and replaces the 'old' 'large' image with the newer slim one

It also modifies the Github Action for deploying to override the `tag` in the `config.yaml`
