### PR TITLE
fix: missing scheme in cleanup script

### DIFF
--- a/.github/workflows/clean-harbor.py
+++ b/.github/workflows/clean-harbor.py
@@ -3,7 +3,7 @@ import requests
 import re
 from datetime import datetime, timedelta
 
-HARBOR_URL = os.environ["OVH_HARBOR_REGISTRY"]
+HARBOR_URL = f"https://{os.environ['OVH_HARBOR_REGISTRY']}"
 PROJECT = "eopf-toolkit-dev"
 REPO = "eopf-toolkit-dev"
 USERNAME = os.environ["OVH_HARBOR_ROBOT_USERNAME"]


### PR DESCRIPTION
# What this PR is

The value of `OVH_HARBOR_REGISTRY` doesn't contain `https://` as it's not necessary for docker, this broke the cleanup action run last night: https://github.com/eopf-toolkit/eopf-101/actions/runs/15456494446/job/43509622385#step:5:35

This PR fixes that.
