### PR TITLE
Update publish workflow to trigger on release events

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
+  release:
+    types: [published]
 
 name: Quarto Publish
 


### PR DESCRIPTION
This PR to trigger the book book publication only on:

- Release publications (`release: types: [published]`) - ensuring the book is published only when a formal release is created
- Manual workflow dispatch - allowing for emergency or testing scenarios

This change removes the automatic publication on pushes to the main branch (or merge of PRs), ensuring that only well-reviewed changes that have gone through the release process will be published to the book.

This will help us to be more dynamic on PRs

cc @jwagemann @pantierra
