### PR TITLE
Add initial R tutorial

### DIFF
--- a/51_eopf_stac_r.ipynb
+++ b/51_eopf_stac_r.ipynb
@@ -1059,7 +1059,11 @@
         "\n",
         "## Conclusion\n",
         "\n",
-        "This tutorial has provided a clear and practical introduction on how you can programmatically access and search through EOPF Sentinel Zarr Sample Service STAC API using R."
+        "This tutorial has provided a clear and practical introduction on how you can programmatically access and search through EOPF Sentinel Zarr Sample Service STAC API using R.\n",
+        "\n",
+        "## What's next?\n",
+        "\n",
+        "A tutorial on how to load an item of interest and load the Zarr data into R is coming to EOPF-101 soon! For now, please view this next tutorial in the [EOPF tooling guide](https://github.com/eopf-toolkit/eopf-tooling-guide/blob/main/docs/tutorials/stac_zarr/R/eopf_zarr.md)."
       ]
     }
   ],


### PR DESCRIPTION
This PR adds the initial R tutorial, with more to come! @gisromerocandanedo feel free to update any wording etc as you see fit :)

I was hoping based on https://github.com/eopf-toolkit/eopf-101/pull/37 that there might be R support ready, but I think maybe the container is there (I can't see it on the jupyterlab though!), but that it might not be developed on the website publishing side yet? cc @ciaransweet @jbants 

So this might have to be temporarily put off in favour of a simple `.qmd` that discusses that there are R tutorials available and links out to the tooling guide, especially in time for the webinar on the 16th!