### PR TITLE
feat: add openssh-client to docker images

### DIFF
--- a/deployment/Dockerfile_python
+++ b/deployment/Dockerfile_python
@@ -5,8 +5,10 @@ RUN pip install pdm
 USER root
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends \
+    git \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY ../pyproject.toml /home/${NB_USER}/deps/pyproject.toml
 RUN chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/deps

--- a/deployment/Dockerfile_r
+++ b/deployment/Dockerfile_r
@@ -20,8 +20,10 @@ RUN pip install pdm
 USER root
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends \
+    git \
+    openssh-client \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY ../pyproject.toml /home/${NB_USER}/deps/pyproject.toml
 RUN chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/deps


### PR DESCRIPTION
# What this PR is

To be able to authenticate to github to push anything, users will need to either create `ssh` keys or use PAT's on GitHub.

Right now the image is super lightweight and has no `ssh-keygen` so I'm adding `openssh-client`

# How I did it

- Modified `Dockerfile_r` and `Dockerfile_python` with `openssh-client` in the apt installs

# How you can test it

You can `make build-docker-image PROJECT=[r|python]`

Then run:

`docker run -p 8888:8888 eopf-toolkit-[r|python]`

Copy the token from the terminal, go to `localhost:8888` and paste in the token, put an easy password in, then on the Jupyterlab interface open up a terminal and run `ssh-keygen` to confirm it's installed.
