### PR TITLE
feat: add env vars for render bucket in OVH

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,3 +79,4 @@ jobs:
           BUCKET_NAME: ${{ secrets.RENDER_BUCKET_NAME }}
           ACCESS_KEY: ${{ secrets.RENDER_BUCKET_ACCESS_KEY }}
           SECRET_KEY: ${{ secrets.RENDER_BUCKET_SECRET_KEY }}
+          BUCKET_ENDPOINT: ${{ secrets.RENDER_BUCKET_ENDPOINT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,3 +180,4 @@ jobs:
           BUCKET_NAME: ${{ secrets.RENDER_BUCKET_NAME }}
           ACCESS_KEY: ${{ secrets.RENDER_BUCKET_ACCESS_KEY }}
           SECRET_KEY: ${{ secrets.RENDER_BUCKET_SECRET_KEY }}
+          BUCKET_ENDPOINT: ${{ secrets.RENDER_BUCKET_ENDPOINT }}


### PR DESCRIPTION
# What this PR is

Some contributors need S3API compatible bucket access in the running of their notebooks.

We're expecting them to expect `BUCKET_NAME`, `ACCESS_KEY`, and `SECRET_KEY`

We'll provide these at render and publish

# How I did it

- Created the bucket in OVH
- Generated credentials
- Added secrets to Github Actions
- Modified `.github/workflows/test.yml` and `.github/workflows/publish.yml` to provide bucket related env vars to the `render` and `publish` steps

# How you can test it

This PR should just be a noop and we shouldn't notice anything

The test case will be this PR: https://github.com/eopf-toolkit/eopf-101/pull/88
