### PR TITLE
feat: publish gh pages on pushes to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,7 @@
 name: Quarto Publish
 
 on:
-  workflow_dispatch:
-  release:
-    types: [published]
+  push: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
# What this PR does

Removes the need to invoke the publish workflow manually/via releases on GitHub and instead just runs on pushes to `main`
