### PR TITLE
feat: run publish job on large runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
 
   build-deploy:
     needs: prepare-docker-image
-    runs-on: ubuntu-latest
+    runs-on: eopf-large
     if: needs.prepare-docker-image.result == 'success'
     container:
       # We use the R image as this contains the same Python Dependencies as the Python one, so should work for everything


### PR DESCRIPTION
# What this PR does

The Test Render job in PRs runs on `eopf-large`

We should use the same for publishing, as this renders _all_ notebooks - Also something we might want to look into.
