### PR TITLE
fix: set execute.error to false to cause failures in quarto

### DIFF
--- a/05_zarr_tools/53_eopf_zarr_r.qmd
+++ b/05_zarr_tools/53_eopf_zarr_r.qmd
@@ -223,7 +223,7 @@ b02 |>
 
 ## Simple Data Analysis: Calculating NDVI
 
-TestLet us now do a simple analysis with the data from the EOPF Zarr STAC Catalog. Let us calculate the Normalized Difference Vegetation Index (NDVI).
+Let us now do a simple analysis with the data from the EOPF Zarr STAC Catalog. Let us calculate the Normalized Difference Vegetation Index (NDVI).
 
 First, we access the *Red* (B04) and *Near-InfraRed* (B08A) bands, which are needed for calculation of the NDVI, at 20m resolution:
 


### PR DESCRIPTION
# What this PR is

We've noticed that R notebooks with errors are being rendered + published without issue.

Turns out, `execute.error` is very confusing: https://quarto.org/docs/computations/execution-options.html#output-options

```
Include errors in the output (note that this implies that errors executing code will not halt processing of the document).
```

We actually want to set it `false` - We don't want the outputs and we **do** want to halt the processing
