### PR TITLE
chore(ci)!: disable nightly render job

### DIFF
--- a/.github/workflows/nightly-render-check.yml
+++ b/.github/workflows/nightly-render-check.yml
@@ -2,8 +2,8 @@ name: Nightly Render
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
+  # schedule:
+  #   - cron: "0 0 * * *"
 
 jobs:
   test-render:


### PR DESCRIPTION
# What this PR is 

Disables the schedule on the `nightly-render-check.yml` job as it's burning through our budget and we can pickup issues in different ways for the moment.
