### PR TITLE
feat!: switch from OVH Registry to GHCR.io

### DIFF
--- a/.github/workflows/delete-old-image-tags.yml
+++ b/.github/workflows/delete-old-image-tags.yml
@@ -1,36 +1,34 @@
-name: Delete old image tags from Harbor
+name: Delete old image tags from GHCR
 
 on:
   workflow_dispatch:
   schedule:
     - cron: "0 9 * * *"
 
+permissions: {}
+
 jobs:
   delete-old-tags:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
-      - name: Delete old eopf-toolkit-python image tags from Harbor
-        uses: developmentseed/container-registry-cleanup@41ad2d4065be2825ebf0aec1e7d2b3215d5d6d47 # v0.2.0
+      - name: Delete old eopf-toolkit-python image tags from GHCR
+        uses: developmentseed/container-registry-cleanup@f590615d76bd127b94f30e12cfcda9ba6072247a # v0.2.1
         env:
-          REGISTRY_TYPE: harbor
+          REGISTRY_TYPE: ghcr
           REPOSITORY_NAME: eopf-toolkit-python
-          HARBOR_URL: ${{ secrets.OVH_HARBOR_REGISTRY }}
-          HARBOR_USERNAME: ${{ secrets.OVH_HARBOR_USERNAME }}
-          HARBOR_PASSWORD: ${{ secrets.OVH_HARBOR_PASSWORD }}
-          HARBOR_PROJECT_NAME: eopf-toolkit-python
+          GITHUB_REPO_OWNER: eopf-toolkit
           VERSION_PATTERN: ^(release-.*|latest|competition)$
           TEST_RETENTION_DAYS: 7
           DRY_RUN: false
 
-      - name: Delete old eopf-toolkit-r image tags from Harbor
-        uses: developmentseed/container-registry-cleanup@41ad2d4065be2825ebf0aec1e7d2b3215d5d6d47 # v0.2.0
+      - name: Delete old eopf-toolkit-r image tags from GHCR
+        uses: developmentseed/container-registry-cleanup@f590615d76bd127b94f30e12cfcda9ba6072247a # v0.2.1
         env:
-          REGISTRY_TYPE: harbor
+          REGISTRY_TYPE: ghcr
           REPOSITORY_NAME: eopf-toolkit-r
-          HARBOR_URL: ${{ secrets.OVH_HARBOR_REGISTRY }}
-          HARBOR_USERNAME: ${{ secrets.OVH_HARBOR_USERNAME }}
-          HARBOR_PASSWORD: ${{ secrets.OVH_HARBOR_PASSWORD }}
-          HARBOR_PROJECT_NAME: eopf-toolkit-r
+          GITHUB_REPO_OWNER: eopf-toolkit
           VERSION_PATTERN: ^(release-.*|latest|competition)$
           TEST_RETENTION_DAYS: 7
           DRY_RUN: false

--- a/.github/workflows/nightly-render-check.yml
+++ b/.github/workflows/nightly-render-check.yml
@@ -5,12 +5,19 @@ on:
   # schedule:
   #   - cron: "0 0 * * *"
 
+permissions: {}
+
 jobs:
   test-render:
     runs-on: eopf-large
+    permissions:
+      contents: read
     container:
       # We use the R image as this contains the same Python Dependencies as the Python one, so should work for everything
-      image: 4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-r/eopf-toolkit-r:latest
+      image: ghcr.io/eopf-toolkit/eopf-toolkit-r:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       options: --entrypoint "" --user root
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,13 +5,13 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pages: write
+permissions: {}
 
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       image_changes: ${{ steps.filter.outputs.image_changes }}
     steps:
@@ -30,14 +30,17 @@ jobs:
   publish-images:
     needs: detect-changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-      - name: Login to OVH Harbor docker registry
+      - name: Login to GHCR
         if: needs.detect-changes.outputs.image_changes == 'true'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
-          registry: ${{ secrets.OVH_HARBOR_REGISTRY }}
-          username: ${{ secrets.OVH_HARBOR_USERNAME }}
-          password: ${{ secrets.OVH_HARBOR_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
         if: needs.detect-changes.outputs.image_changes == 'true'
@@ -70,10 +73,14 @@ jobs:
     if: needs.publish-images.result == 'success'
     container:
       # We use the R image as this contains the same Python Dependencies as the Python one, so should work for everything
-      image: 4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-r/eopf-toolkit-r:latest
+      image: ghcr.io/eopf-toolkit/eopf-toolkit-r:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       options: --entrypoint "" --user root
     permissions:
       contents: write
+      pages: write
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,12 +55,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # We use the R image as this contains the same Python Dependencies as the Python one, so should work for everything
-      - name: build image
-        working-directory: deployment
+      - name: Set up Docker Buildx
         if: needs.check-diff.outputs.build == 'true'
-        run: |
-          make build-and-push-docker-image TAG=${{ needs.check-diff.outputs.tag }} PROJECT="r"
+        uses: docker/setup-buildx-action@v3
+
+      # We use the R image as this contains the same Python Dependencies as the Python one, so should work for everything
+      - name: Build and push R image
+        if: needs.check-diff.outputs.build == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deployment/Dockerfile_r
+          push: true
+          tags: ghcr.io/eopf-toolkit/eopf-toolkit-r:${{ needs.check-diff.outputs.tag }}
+          platforms: linux/amd64
+          cache-from: type=registry,ref=ghcr.io/eopf-toolkit/eopf-toolkit-r:cache
+          cache-to: type=registry,ref=ghcr.io/eopf-toolkit/eopf-toolkit-r:cache,mode=max
 
   test-render:
     needs: [check-diff, prepare-docker-image]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,13 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions: {}
+
 jobs:
   check-diff:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       build: ${{ steps.check.outputs.build }}
       tag: ${{ steps.check.outputs.tag }}
@@ -35,18 +39,21 @@ jobs:
   prepare-docker-image:
     runs-on: ubuntu-latest
     needs: check-diff
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: needs.check-diff.outputs.build == 'true'
 
-      - name: Login to OVH Harbor docker registry
+      - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         if: needs.check-diff.outputs.build == 'true'
         with:
-          registry: ${{ secrets.OVH_HARBOR_REGISTRY }}
-          username: ${{ secrets.OVH_HARBOR_USERNAME }}
-          password: ${{ secrets.OVH_HARBOR_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # We use the R image as this contains the same Python Dependencies as the Python one, so should work for everything
       - name: build image
@@ -58,10 +65,15 @@ jobs:
   test-render:
     needs: [check-diff, prepare-docker-image]
     runs-on: eopf-large
+    permissions:
+      contents: read
     if: needs.check-diff.result == 'success' && (needs.prepare-docker-image.result == 'success' || needs.prepare-docker-image.result == 'skipped')
     container:
       # We use the R image as this contains the same Python Dependencies as the Python one, so should work for everything
-      image: 4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-r/eopf-toolkit-r:${{ needs.check-diff.outputs.tag }}
+      image: ghcr.io/eopf-toolkit/eopf-toolkit-r:${{ needs.check-diff.outputs.tag }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       options: --entrypoint "" --user root
 
     steps:

--- a/02_about_eopf_zarr/22_zarr_structure_S1GRD.ipynb
+++ b/02_about_eopf_zarr/22_zarr_structure_S1GRD.ipynb
@@ -26,7 +26,7 @@
     }
    },
    "source": [
-    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/02_about_eopf_zarr/22_zarr_structure_S1GRD.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
+    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/02_about_eopf_zarr/22_zarr_structure_S1GRD.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/02_about_eopf_zarr/23_S1_basic_operations.ipynb
+++ b/02_about_eopf_zarr/23_S1_basic_operations.ipynb
@@ -24,7 +24,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/02_about_eopf_zarr/23_S1_basic_operations.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}'>\n",
+    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/02_about_eopf_zarr/23_S1_basic_operations.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}'>\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/02_about_eopf_zarr/24_zarr_struct_S2L2A.ipynb
+++ b/02_about_eopf_zarr/24_zarr_struct_S2L2A.ipynb
@@ -22,7 +22,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href= 'https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/02_about_eopf_zarr/24_zarr_struct_S2L2A.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
+    "<a href= 'https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/02_about_eopf_zarr/24_zarr_struct_S2L2A.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
     "\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",

--- a/02_about_eopf_zarr/25_zarr_struct_S3.ipynb
+++ b/02_about_eopf_zarr/25_zarr_struct_S3.ipynb
@@ -22,7 +22,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href= 'https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/02_about_eopf_zarr/25_zarr_struct_S3.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
+    "<a href= 'https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/02_about_eopf_zarr/25_zarr_struct_S3.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/04_eopf_and_stac/43_eopf_stac_connection.ipynb
+++ b/04_eopf_and_stac/43_eopf_stac_connection.ipynb
@@ -22,7 +22,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F04_eopf_and_stac%252F43_eopf_stac_connection.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%224zm3809f.c1.de1.container-registry.ovh.net%2Feopf-toolkit-python%2Feopf-toolkit-python%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
+    "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F04_eopf_and_stac%252F43_eopf_stac_connection.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%22ghcr.io%2Feopf-toolkit%2Feopf-toolkit-python%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/04_eopf_and_stac/44_eopf_stac_xarray_tutorial.ipynb
+++ b/04_eopf_and_stac/44_eopf_stac_xarray_tutorial.ipynb
@@ -24,7 +24,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F04_eopf_and_stac%252F44_eopf_stac_xarray_tutorial.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%224zm3809f.c1.de1.container-registry.ovh.net%2Feopf-toolkit-python%2Feopf-toolkit-python%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
+    "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F04_eopf_and_stac%252F44_eopf_stac_xarray_tutorial.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%22ghcr.io%2Feopf-toolkit%2Feopf-toolkit-python%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/05_zarr_tools/51_eopf_stac_r.ipynb
+++ b/05_zarr_tools/51_eopf_stac_r.ipynb
@@ -4,7 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F05_zarr_tools%252F51_eopf_stac_r.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%224zm3809f.c1.de1.container-registry.ovh.net%2Feopf-toolkit-r%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
+        "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F05_zarr_tools%252F51_eopf_stac_r.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%22ghcr.io%2Feopf-toolkit%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
         "<button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
         "🚀 Launch this notebook in JupyterLab\n",
         "</button>\n",

--- a/05_zarr_tools/51_eopf_stac_r.qmd
+++ b/05_zarr_tools/51_eopf_stac_r.qmd
@@ -8,7 +8,7 @@ link_start <- "https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspaw
 folder <- "05_zarr_tools"
 separator <- "%252F"
 file <- "51_eopf_stac_r.ipynb"
-link_end <- "%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%224zm3809f.c1.de1.container-registry.ovh.net%2Feopf-toolkit-r%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D"
+link_end <- "%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%22ghcr.io%2Feopf-toolkit%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D"
 
 jupyterlab_link <- paste0(link_start, folder, separator, file, link_end)
 ```

--- a/05_zarr_tools/53_eopf_zarr_r.ipynb
+++ b/05_zarr_tools/53_eopf_zarr_r.ipynb
@@ -4,7 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F05_zarr_tools%252F53_eopf_zarr_r.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%224zm3809f.c1.de1.container-registry.ovh.net%2Feopf-toolkit-r%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
+        "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F05_zarr_tools%252F53_eopf_zarr_r.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%22ghcr.io%2Feopf-toolkit%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
         "<button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
         "🚀 Launch this notebook in JupyterLab\n",
         "</button>\n",

--- a/05_zarr_tools/53_eopf_zarr_r.qmd
+++ b/05_zarr_tools/53_eopf_zarr_r.qmd
@@ -13,7 +13,7 @@ link_start <- "https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspaw
 folder <- "05_zarr_tools"
 separator <- "%252F"
 file <- "53_eopf_zarr_r.ipynb"
-link_end <- "%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%224zm3809f.c1.de1.container-registry.ovh.net%2Feopf-toolkit-r%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D"
+link_end <- "%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%22ghcr.io%2Feopf-toolkit%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D"
 
 jupyterlab_link <- paste0(link_start, folder, separator, file, link_end)
 ```

--- a/05_zarr_tools/54_eopf_zarr_r_examples.ipynb
+++ b/05_zarr_tools/54_eopf_zarr_r_examples.ipynb
@@ -4,7 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F05_zarr_tools%252F54_eopf_zarr_r_examples.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%224zm3809f.c1.de1.container-registry.ovh.net%2Feopf-toolkit-r%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
+        "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F05_zarr_tools%252F54_eopf_zarr_r_examples.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%22ghcr.io%2Feopf-toolkit%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
         "<button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
         "🚀 Launch this notebook in JupyterLab\n",
         "</button>\n",

--- a/05_zarr_tools/54_eopf_zarr_r_examples.qmd
+++ b/05_zarr_tools/54_eopf_zarr_r_examples.qmd
@@ -12,7 +12,7 @@ link_start <- "https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspaw
 folder <- "05_zarr_tools"
 separator <- "%252F"
 file <- "54_eopf_zarr_r_examples.ipynb"
-link_end <- "%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%224zm3809f.c1.de1.container-registry.ovh.net%2Feopf-toolkit-r%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D"
+link_end <- "%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%22ghcr.io%2Feopf-toolkit%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D"
 
 jupyterlab_link <- paste0(link_start, folder, separator, file, link_end)
 ```

--- a/05_zarr_tools/56_zarr_R_rarr.ipynb
+++ b/05_zarr_tools/56_zarr_R_rarr.ipynb
@@ -4,7 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F05_zarr_tools%252F56_zarr_R_rarr.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%224zm3809f.c1.de1.container-registry.ovh.net%2Feopf-toolkit-r%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
+        "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F05_zarr_tools%252F56_zarr_R_rarr.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%22ghcr.io%2Feopf-toolkit%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
         "<button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
         "🚀 Launch this notebook in JupyterLab\n",
         "</button>\n",

--- a/05_zarr_tools/56_zarr_R_rarr.qmd
+++ b/05_zarr_tools/56_zarr_R_rarr.qmd
@@ -10,7 +10,7 @@ link_start <- "https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspaw
 folder <- "05_zarr_tools"
 separator <- "%252F"
 file <- "56_zarr_R_rarr.ipynb"
-link_end <- "%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%224zm3809f.c1.de1.container-registry.ovh.net%2Feopf-toolkit-r%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D"
+link_end <- "%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%22ghcr.io%2Feopf-toolkit%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D"
 
 jupyterlab_link <- paste0(link_start, folder, separator, file, link_end)
 ```

--- a/05_zarr_tools/57_zarr_R_gdal.ipynb
+++ b/05_zarr_tools/57_zarr_R_gdal.ipynb
@@ -4,7 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F05_zarr_tools%252F57_zarr_R_gdal.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%224zm3809f.c1.de1.container-registry.ovh.net%2Feopf-toolkit-r%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
+        "<a href=\"https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspawn%3Fnext%3D%252Fhub%252Fuser-redirect%252Fgit-pull%253Frepo%253Dhttps%253A%252F%252Fgithub.com%252Feopf-toolkit%252Feopf-101%2526branch%253Dmain%2526urlpath%253Dlab%252Ftree%252Feopf-101%252F05_zarr_tools%252F57_zarr_R_gdal.ipynb%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%22ghcr.io%2Feopf-toolkit%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D\" target=\"_blank\">\n",
         "<button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
         "🚀 Launch this notebook in JupyterLab\n",
         "</button>\n",

--- a/05_zarr_tools/57_zarr_R_gdal.qmd
+++ b/05_zarr_tools/57_zarr_R_gdal.qmd
@@ -12,7 +12,7 @@ link_start <- "https://jupyterhub.user.eopf.eodc.eu/hub/login?next=%2Fhub%2Fspaw
 folder <- "05_zarr_tools"
 separator <- "%252F"
 file <- "57_zarr_R_gdal.ipynb"
-link_end <- "%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%224zm3809f.c1.de1.container-registry.ovh.net%2Feopf-toolkit-r%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D"
+link_end <- "%23fancy-forms-config=%7B%22profile%22%3A%22choose-your-environment%22%2C%22image%22%3A%22unlisted_choice%22%2C%22image%3Aunlisted_choice%22%3A%22ghcr.io%2Feopf-toolkit%2Feopf-toolkit-r%3Alatest%22%2C%22autoStart%22%3A%22true%22%7D"
 
 jupyterlab_link <- paste0(link_start, folder, separator, file, link_end)
 ```

--- a/06_eopf_zarr_in_action/610_s2_s3_fusion.ipynb
+++ b/06_eopf_zarr_in_action/610_s2_s3_fusion.ipynb
@@ -22,7 +22,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/610_s2_s3_fusion.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
+    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/610_s2_s3_fusion.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/06_eopf_zarr_in_action/61_sardinia_s2_tfci.ipynb
+++ b/06_eopf_zarr_in_action/61_sardinia_s2_tfci.ipynb
@@ -22,7 +22,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/61_sardinia_s2_tfci.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
+    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/61_sardinia_s2_tfci.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/06_eopf_zarr_in_action/62_sardinia_s3_lst.ipynb
+++ b/06_eopf_zarr_in_action/62_sardinia_s3_lst.ipynb
@@ -22,7 +22,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/62_sardinia_s3_lst.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
+    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/62_sardinia_s3_lst.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/06_eopf_zarr_in_action/63_sardinia_dNBR.ipynb
+++ b/06_eopf_zarr_in_action/63_sardinia_dNBR.ipynb
@@ -22,7 +22,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href= 'https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/63_sardinia_dNBR.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}'  target=\"_blank\">\n",
+    "<a href= 'https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/63_sardinia_dNBR.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}'  target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/06_eopf_zarr_in_action/64_flood_mapping_valencia.ipynb
+++ b/06_eopf_zarr_in_action/64_flood_mapping_valencia.ipynb
@@ -22,7 +22,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/64_flood_mapping_valencia.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
+    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/64_flood_mapping_valencia.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/06_eopf_zarr_in_action/65_create_overviews.ipynb
+++ b/06_eopf_zarr_in_action/65_create_overviews.ipynb
@@ -22,7 +22,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/65_create_overviews.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
+    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/65_create_overviews.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/06_eopf_zarr_in_action/66_use_overviews.ipynb
+++ b/06_eopf_zarr_in_action/66_use_overviews.ipynb
@@ -24,7 +24,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href= 'https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/66_use_overviews.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
+    "<a href= 'https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/66_use_overviews.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/06_eopf_zarr_in_action/67_reservoir_surface_monitoring.ipynb
+++ b/06_eopf_zarr_in_action/67_reservoir_surface_monitoring.ipynb
@@ -26,7 +26,7 @@
     }
    },
    "source": [
-    "<a href= 'https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/67_reservoir_surface_monitoring.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
+    "<a href= 'https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/67_reservoir_surface_monitoring.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/06_eopf_zarr_in_action/68_vegetation_anomalies.ipynb
+++ b/06_eopf_zarr_in_action/68_vegetation_anomalies.ipynb
@@ -26,7 +26,7 @@
     }
    },
    "source": [
-    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/68_vegetation_anomalies.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
+    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/68_vegetation_anomalies.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/06_eopf_zarr_in_action/69_coastal_water_dynamics_s1.ipynb
+++ b/06_eopf_zarr_in_action/69_coastal_water_dynamics_s1.ipynb
@@ -22,7 +22,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/69_coastal_water_dynamics_s1.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
+    "<a href='https://jupyterhub.user.eopf.eodc.eu/hub/login?next=/hub/spawn?next=/hub/user-redirect/git-pull?repo=https://github.com/eopf-toolkit/eopf-101&branch=main&urlpath=lab/tree/eopf-101/06_eopf_zarr_in_action/69_coastal_water_dynamics_s1.ipynb#fancy-forms-config={\"profile\":\"choose-your-environment\",\"image\":\"unlisted_choice\",\"image:unlisted_choice\":\"ghcr.io/eopf-toolkit/eopf-toolkit-python:latest\",\"autoStart\":\"true\"}' target=\"_blank\">\n",
     "  <button style=\"background-color:#0072ce; color:white; padding:0.6em 1.2em; font-size:1rem; border:none; border-radius:6px; margin-top:1em;\">\n",
     "    🚀 Launch this notebook in JupyterLab\n",
     "  </button>\n",

--- a/deployment/Dockerfile_python
+++ b/deployment/Dockerfile_python
@@ -1,27 +1,27 @@
 FROM quay.io/jupyter/base-notebook:python-3.12.10
 
-RUN pip install uv
-
 USER root
-
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     git \
     openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-ENV PATH=${CONDA_DIR}/bin:$PATH
+USER ${NB_UID}
+
+RUN pip install uv
 
 COPY ../pyproject.toml /home/${NB_USER}/deps/pyproject.toml
 COPY ../uv.lock /home/${NB_USER}/deps/uv.lock
 
+USER root
 RUN chown -R ${NB_UID}:${NB_GID} /home/${NB_USER}/deps
-
 USER ${NB_UID}
 
-WORKDIR /home/${NB_USER}/deps 
+WORKDIR /home/${NB_USER}/deps
 
 ENV UV_PROJECT_ENVIRONMENT=${CONDA_DIR}
+ENV PATH=${CONDA_DIR}/bin:$PATH
 
 RUN uv sync --frozen --no-install-project --inexact
 

--- a/deployment/Dockerfile_r
+++ b/deployment/Dockerfile_r
@@ -1,20 +1,6 @@
 FROM quay.io/jupyter/r-notebook:python-3.12.10
 
-COPY ../deployment/environment.yaml environment.yaml
-
-RUN mamba env update -n base -f environment.yaml && \
-    mamba clean --all -f -y && \
-    rm environment.yaml && \
-    fix-permissions "${CONDA_DIR}" && \
-    fix-permissions "/home/${NB_USER}"
-
-ENV PROJ_LIB=${CONDA_DIR}/share/proj
-ENV GDAL_DATA=${CONDA_DIR}/share/gdal
-
-RUN pip install uv
-
 USER root
-
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     git \
@@ -27,7 +13,6 @@ RUN apt-get update && \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Julia
 ARG JULIA_VERSION=1.11.5
 RUN mkdir -p /opt/julia && \
     cd /tmp && \
@@ -39,19 +24,6 @@ RUN mkdir -p /opt/julia && \
 
 USER ${NB_UID}
 
-ENV R_LIBS_USER=${CONDA_DIR}/lib/R/library
-
-RUN Rscript -e 'options(repos = c(CRAN="https://cloud.r-project.org")); \
-    if (!requireNamespace("BiocManager", quietly=TRUE)) install.packages("BiocManager"); \
-    if (!requireNamespace("remotes", quietly=TRUE)) install.packages("remotes"); \
-    repos <- BiocManager::repositories(); \
-    ok <- TRUE; \
-    tryCatch({ remotes::install_version("Rarr", version="1.10.1", repos=repos, upgrade="never") }, \
-    error=function(e) { message("Pinned install failed, falling back to BiocManager::install('Rarr')"); ok <<- FALSE }); \
-    if (!ok) BiocManager::install("Rarr", ask=FALSE, update=FALSE); \
-    cat("Installed Rarr version:", as.character(packageVersion("Rarr")), "\n")'
-
-# Set Julia depot path and install Julia packages
 ENV JULIA_DEPOT_PATH=/home/${NB_USER}/.julia
 
 RUN julia -e 'using Pkg; \
@@ -69,7 +41,29 @@ RUN julia -e 'using Pkg; \
     Pkg.precompile();' && \
     fix-permissions "${JULIA_DEPOT_PATH}"
 
-ENV PATH=${CONDA_DIR}/bin:$PATH
+COPY ../deployment/environment.yaml environment.yaml
+
+RUN mamba env update -n base -f environment.yaml && \
+    mamba clean --all -f -y && \
+    rm environment.yaml && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+ENV PROJ_LIB=${CONDA_DIR}/share/proj
+ENV GDAL_DATA=${CONDA_DIR}/share/gdal
+ENV R_LIBS_USER=${CONDA_DIR}/lib/R/library
+
+RUN Rscript -e 'options(repos = c(CRAN="https://cloud.r-project.org")); \
+    if (!requireNamespace("BiocManager", quietly=TRUE)) install.packages("BiocManager"); \
+    if (!requireNamespace("remotes", quietly=TRUE)) install.packages("remotes"); \
+    repos <- BiocManager::repositories(); \
+    ok <- TRUE; \
+    tryCatch({ remotes::install_version("Rarr", version="1.10.1", repos=repos, upgrade="never") }, \
+    error=function(e) { message("Pinned install failed, falling back to BiocManager::install(Rarr)"); ok <<- FALSE }); \
+    if (!ok) BiocManager::install("Rarr", ask=FALSE, update=FALSE); \
+    cat("Installed Rarr version:", as.character(packageVersion("Rarr")), "\n")'
+
+RUN pip install uv
 
 COPY ../pyproject.toml /home/${NB_USER}/deps/pyproject.toml
 COPY ../uv.lock /home/${NB_USER}/deps/uv.lock
@@ -81,13 +75,13 @@ USER ${NB_UID}
 WORKDIR /home/${NB_USER}/deps
 
 ENV UV_PROJECT_ENVIRONMENT=${CONDA_DIR}
+ENV PATH=${CONDA_DIR}/bin:$PATH
 
 RUN uv sync --frozen --no-install-project --inexact
 
 WORKDIR /home/${NB_USER}
 RUN rm -rf deps
 
-# Verify all environments
 RUN echo "=== Python ===" && \
     python --version && \
     echo "=== R ===" && \

--- a/deployment/Dockerfile_r
+++ b/deployment/Dockerfile_r
@@ -28,7 +28,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Julia
-ARG JULIA_VERSION=1.12.5
+ARG JULIA_VERSION=1.11.5
 RUN mkdir -p /opt/julia && \
     cd /tmp && \
     wget -q https://julialang-s3.julialang.org/bin/linux/x64/$(echo ${JULIA_VERSION} | cut -d. -f1,2)/julia-${JULIA_VERSION}-linux-x86_64.tar.gz && \

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -10,10 +10,10 @@ build-docker-image:
 	DOCKER_DEFAULT_PLATFORM="linux/amd64" docker build --no-cache -f $(ROOT_DIR)/deployment/Dockerfile_$(PROJECT) -t eopf-toolkit-$(PROJECT) $(ROOT_DIR)
 
 tag-docker-image:
-	docker tag eopf-toolkit-$(PROJECT) 4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-$(PROJECT)/eopf-toolkit-$(PROJECT):$(TAG)
+	docker tag eopf-toolkit-$(PROJECT) ghcr.io/eopf-toolkit/eopf-toolkit-$(PROJECT):$(TAG)
 
 push-docker-image:
-	docker push 4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-$(PROJECT)/eopf-toolkit-$(PROJECT):$(TAG)
+	docker push ghcr.io/eopf-toolkit/eopf-toolkit-$(PROJECT):$(TAG)
 
 build-and-push-docker-image: build-docker-image tag-docker-image push-docker-image
 	@echo "Docker image built and pushed with tag: $(TAG)"

--- a/deployment/config.yaml
+++ b/deployment/config.yaml
@@ -45,10 +45,8 @@ hub:
 singleuser:
   image:
     # This `latest` should ideally be replaced during CI deployments
-    name: 4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python
+    name: ghcr.io/eopf-toolkit/eopf-toolkit-python
     tag: "latest"
-    pullSecrets:
-      - name: regcred
   profileList:
       - display_name: "Python"
         description: "Python environment powered by eopf-toolkit-python"
@@ -56,6 +54,4 @@ singleuser:
       - display_name: "R"
         description: "R environment powered by eopf-toolkit-r"
         kubespawner_override:
-          image: 4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-r/eopf-toolkit-r:latest
-          pullSecrets:
-            - name: regcred
+          image: ghcr.io/eopf-toolkit/eopf-toolkit-r:latest

--- a/index.qmd
+++ b/index.qmd
@@ -101,10 +101,10 @@ Once you click, the following box is displayed:
 In the box, you can copy and paste the following custom lines:
 
 * If you would like to develop your workflow in Python:<br>
-`4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-python/eopf-toolkit-python:competition`
+`ghcr.io/eopf-toolkit/eopf-toolkit-python:latest`
 
 * Or, if you prefer to use R:<br>
-`4zm3809f.c1.de1.container-registry.ovh.net/eopf-toolkit-r/eopf-toolkit-r:competition`
+`ghcr.io/eopf-toolkit/eopf-toolkit-r:latest`
 
 And select **Start**.
 


### PR DESCRIPTION
# What this PR is 

Moves publishing images to ghcr.io

# How I did it

Moved all references to the OVH registry to `ghcr.io/eopf-toolkit/eopf-toolkit-(r|python):{tag}` including links in notebooks. 

This _might_ break given those packages don't exist right now, but let's see what CI does.
