### PR TITLE
feat: add dependabot config to update pyproject and uv.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# What this PR is

Right now the dependabot PRs don't update `pyproject.toml`, just `uv.lock`, it appears if you set `package-ecosystem: uv` in the config file, it will update both.
